### PR TITLE
Implement run test at point.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ The `overseer-mode` minor mode will be automaticly enable the following keybindi
 
 Keybinding           | Description
 ---------------------|---------------
-<kbd>C-c , t</kbd>   | Runs `cask exec ert-runner`. `overseer-test`
+<kbd>C-c , a</kbd>   | Runs `cask exec ert-runner`. `overseer-test`
+<kbd>C-c , t</kbd>   | Runs `cask exec ert-runner -p <test-at-point>`. `overseer-test-run-test`
 <kbd>C-c , b</kbd>   | Runs `cask exec ert-runner` with the current buffer file as argument. `overseer-test-this-buffer`
 <kbd>C-c , f</kbd>   | Open a prompt to run `cask exec ert-runner` with a custom file as arguments. `overseer-test-file`
 <kbd>C-c , g</kbd>   | Runs `cask exec ert-runner -t` with given tags (example: `indentation,syntax`). `overseer-test-this-buffer`

--- a/overseer.el
+++ b/overseer.el
@@ -144,6 +144,7 @@
   "Run ert-runner for the test at point."
   (interactive)
   (save-excursion
+    (end-of-defun)
     (beginning-of-defun)
     (let ((function (read (current-buffer))))
       (if (string= "ert-deftest" (car function))

--- a/overseer.el
+++ b/overseer.el
@@ -96,6 +96,10 @@
   "Run ert-runner with the current FILENAME as argument."
   (overseer-execute (list (expand-file-name filename))))
 
+(defun overseer--test-pattern (pattern)
+  "Run ert-runner for tests matching PATTERN."
+  (overseer-execute (list "-p" pattern)))
+
 (defun overseer--current-buffer-test-file-p ()
   "Return t if the current buffer is a test file."
   (string-match "-test\.el$" (or (buffer-file-name) "")))
@@ -135,6 +139,16 @@
   "Run ert-runner."
   (interactive)
   (overseer-execute '()))
+
+(defun overseer-test-run-test ()
+  "Run ert-runner for the test at point."
+  (interactive)
+  (save-excursion
+    (beginning-of-defun)
+    (let ((function (read (current-buffer))))
+      (if (string= "ert-deftest" (car function))
+          (overseer--test-pattern (symbol-name (cadr function)))
+        (message "No test at point")))))
 
 (defun overseer-help ()
   "Run ert-runner with --help as argument."
@@ -206,7 +220,8 @@ just return nil."
 
 (defvar overseer-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c , t") 'overseer-test)
+    (define-key map (kbd "C-c , a") 'overseer-test)
+    (define-key map (kbd "C-c , t") 'overseer-test-run-test)
     (define-key map (kbd "C-c , b") 'overseer-test-this-buffer)
     (define-key map (kbd "C-c , f") 'overseer-test-file)
     (define-key map (kbd "C-c , g") 'overseer-test-tags)


### PR DESCRIPTION
Fixes tonini/overseer.el#7

Inspired by https://github.com/clojure-emacs/cider I have followed their example in naming the function for testing at a point as overseer-test-run-test, and a default binding of 't'.
