### PR TITLE
add missing require to 'f' package

### DIFF
--- a/overseer.el
+++ b/overseer.el
@@ -32,6 +32,7 @@
 
 (require 'compile)
 (require 'dash)
+(require 'f)
 (require 'pkg-info)
 (require 'ansi-color)
 


### PR DESCRIPTION
I had an error when I used this because you use `f-slash`.