### PR TITLE
Add better overseer-test-prompt history.

### DIFF
--- a/overseer.el
+++ b/overseer.el
@@ -190,9 +190,18 @@
   (interactive "Mert-runner -t: ")
   (overseer-execute (list "-t" tags)))
 
+(defvar overseer--prompt-history nil
+  "List of recent prompts read from minibuffer.")
+
 (defun overseer-test-prompt (command)
   "Run ert-runner with custom arguments."
-  (interactive "Mert-runner: ")
+  (interactive
+   (list (let ((default (car-safe overseer--prompt-history)))
+           (read-string
+            (if default
+                (format "ert-runner (default \"%s\"): " default)
+              "ert-runner ")
+            nil 'overseer--prompt-history default t))))
   (overseer-execute (list command)))
 
 (defun overseer-execute (cmdlist)


### PR DESCRIPTION
This patch adds a separate history list for `overseer-test-prompt`.
First time user runs this, they have no choice but to enter the prompt
text.  Next time however, the previous input is made the default, so
they can simply RET to confirm to re-run the previous input.

Using `M-n` and `M-p` the user can browse the prompt history.  Selecting
any item from the history makes it the default for the next run.
