### PR TITLE
Use string-prefix-p rather than taking prefix manually

### DIFF
--- a/overseer.el
+++ b/overseer.el
@@ -62,8 +62,7 @@
   "Files which indicate a root of a emacs lisp package.")
 
 (defvar overseer--save-buffers-predicate
-  (lambda ()
-    (not (string= (substring (buffer-name) 0 1) "*"))))
+  (lambda () (string-prefix-p "*" (buffer-name))))
 
 ;; Private functions
 


### PR DESCRIPTION
The package requires emacs 24 which and this function was introduced in 24.4 so
this should be fine.