### PR TITLE
Error rather than return nil on overseer-project-root

### DIFF
--- a/overseer.el
+++ b/overseer.el
@@ -110,7 +110,9 @@
 (defun overseer-project-root ()
   "Return path to the current emacs lisp package root directory."
   (let ((file (file-name-as-directory (expand-file-name default-directory))))
-    (overseer--project-root-identifier file overseer--project-root-indicators)))
+    (or
+     (overseer--project-root-identifier file overseer--project-root-indicators)
+     (user-error "Overseer unable to identify project root"))))
 
 (define-compilation-mode overseer-buffer-mode "ert-runner"
   "Overseer compilation mode."


### PR DESCRIPTION
If overseer is unable to find the project root it's unable to do something
useful elsewhere currently anyway.

We could discuss having a better default here, but it should probably be done separately as this PR is basically a bug fix as well. As overseer can't really handle a nil project root.