### PR TITLE
define-minor-mode: use keyword arguments

### DIFF
--- a/overseer.el
+++ b/overseer.el
@@ -254,8 +254,8 @@ just return nil."
 
 Key bindings:
 \\{overseer-mode-map}"
-  nil
-  " overseer"
+  :init-value nil
+  :lighter " overseer"
   :group 'overseer
   :global nil
   :keymap 'overseer-mode-map)


### PR DESCRIPTION
On Emacs 28, `define-minor-mode`s positional arguments are deprecated,
and using them emits the following warning: "Use keywords rather than
deprecated positional arguments to `define-minor-mode'".

With change prevents this warning.